### PR TITLE
assert that a recent version of Go is installed

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,6 +13,9 @@ jobs:
       with:
         fetch-depth: 0
     - uses: actions/setup-python@v3
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '>=1.18'
     - uses: actions/cache@v3
       with:
         path: |


### PR DESCRIPTION
Go is required for shfmt used in the pre-commit hook.